### PR TITLE
Adjusts configuration to work with podman and ramalama

### DIFF
--- a/.env.ramalama
+++ b/.env.ramalama
@@ -1,10 +1,9 @@
 OPENAI_BASE_URL=http://localhost:8080/v1
 OPENAI_API_KEY=unused
-# TODO(ramalama): figure out how to configure for serving multiple models under
-# the same endpoint.
+# RamaLama cannot currently run multiple models on the same port. So, if you
+# want to run 07-eval, set CHAT_MODEL to EVAL_MODEL's value.
+# See https://github.com/containers/ramalama/issues/598 for more.
 CHAT_MODEL=qwen2.5:0.5b
-# Eval model must be able larger to understand json format, and not itself
-# hallucinate when scoring metrics.
 EVAL_MODEL=deepseek-r1:14b
 
 OTEL_SERVICE_NAME=testing-genai

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,13 @@ on:
       - lychee.toml
       - Makefile
 
+permissions:
+  contents: read
+
+env:
+  # Ensure we can see the server log if an integration test fails.
+  TRAP_PARENT_SERVER_LOG: "trap 'if [ $? -ne 0 ]; then cat ../server.log; fi' ERR"
+
 jobs:
   test:
     runs-on: ubuntu-24.04
@@ -39,26 +46,39 @@ jobs:
       matrix:
         include:
           - name: "ollama"
-            port: 11434
-            install: "curl -fsSL https://ollama.com/install.sh | sh"
             pre_serve: "echo"
             serve: "ollama serve"
+            health: http://127.0.0.1:11434
           - name: "ramalama"
-            port: 8080
-            install: "pip install ramalama"
-            pull: "dotenv run -- sh -c 'ramalama pull ${CHAT_MODEL}'"
-            serve: "dotenv run -- sh -c 'ramalama serve ${CHAT_MODEL}'"
+            pre_serve: "dotenv run -- sh -c 'ramalama pull ${CHAT_MODEL}'"
+            serve: "dotenv run -- sh -c 'ramalama --nocontainer serve ${CHAT_MODEL}'"
+            health: http://127.0.0.1:8080/health
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python 3.12
         uses: actions/setup-python@v5
         with:
           python-version: 3.12
-      - name: Install common dependencies
+      - name: Install dotenv
         run: |
           python -m pip install --upgrade pip
           pip install 'python-dotenv[cli]'
-          ${{ matrix.install }}
+      - name: Install Ollama
+        if: ${{ matrix.name == 'ollama' }}
+        run: curl -fsSL https://ollama.com/install.sh | sh
+      - name: Install RamaLama
+        if: ${{ matrix.name == 'ramalama' }}
+        # In nocontainer mode, RamaLama runs llama-server processes directly.
+        # We install it from the latest llama.cpp release.
+        run: |
+          pip install ramalama
+          TAG=$(gh release view --repo ggml-org/llama.cpp --json tagName --jq .tagName)
+          gh release download $TAG --repo ggml-org/llama.cpp --pattern "llama-${TAG}-bin-ubuntu-x64.zip" --dir .
+          unzip "llama-${TAG}-bin-ubuntu-x64.zip" -d ${{ github.workspace }}/llama.cpp
+          echo "${{ github.workspace }}/llama.cpp/build/bin" >> $GITHUB_PATH
+          echo "LD_LIBRARY_PATH=${{ github.workspace }}/llama.cpp/build/bin" >> $GITHUB_ENV
+        env:
+          GH_TOKEN: ${{ github.token }}
       - name: Create .env file
         run: |
           (cat .env.${{ matrix.name }}; echo; cat .env.otel.console) > .env
@@ -66,24 +86,28 @@ jobs:
         run: |
           ${{ matrix.pre_serve }}
           nohup ${{ matrix.serve }} > server.log 2>&1 &
-          time curl --retry 10 --retry-connrefused --retry-delay 2 -sf http://localhost:${{ matrix.port }} || cat server.log
+          trap 'if [ $? -ne 0 ]; then cat server.log; fi' ERR
+          time curl --retry 10 --retry-connrefused --retry-delay 2 -sf ${{ matrix.health }}
       - name: Test model
         run: dotenv run -- sh -c '${{ matrix.name }} run ${CHAT_MODEL} hello' || cat server.log
       - name: 05-test
         run: |
           pip install -r requirements.txt
           pip install -r requirements-dev.txt
-          pytest || cat ../server.log
+          ${{ env.TRAP_PARENT_SERVER_LOG }}
+          pytest
         working-directory: 05-test
       - name: 06-http-replay
         run: |
           pip install -r requirements.txt
           pip install -r requirements-dev.txt
-          pytest -m integration || cat ../server.log
+          ${{ env.TRAP_PARENT_SERVER_LOG }}
+          pytest -m integration
         working-directory: 06-http-replay
       - name: 07-eval
         run: |  # not "-m eval" as the EVAL_MODEL is too big for CI
           pip install -r requirements.txt
           pip install -r requirements-dev.txt
-          pytest -m integration || cat ../server.log
+          ${{ env.TRAP_PARENT_SERVER_LOG }}
+          pytest -m integration
         working-directory: 07-eval

--- a/01-start/docker-compose.yml
+++ b/01-start/docker-compose.yml
@@ -9,6 +9,6 @@ services:
     build:
       context: .
     extra_hosts:  # send localhost traffic to the docker host, e.g. your laptop
-      - "localhost:host-gateway"
+      - "localhost:${HOST_IP:-host-gateway}"
     volumes:
       - ../.env:/.env

--- a/02-proxy/docker-compose.yml
+++ b/02-proxy/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     build:
       context: .
     extra_hosts:  # send localhost traffic to the docker host, e.g. your laptop
-      - "localhost:host-gateway"
+      - "localhost:${HOST_IP:-host-gateway}"
     volumes:  # Add volumes for our environment variables and mitmproxy's certs
       - ./.env:/.env
       - ./.mitmproxy/mitmproxy-ca-cert.pem:/.mitmproxy/mitmproxy-ca-cert.pem

--- a/03-opentelemetry/docker-compose.yml
+++ b/03-opentelemetry/docker-compose.yml
@@ -9,6 +9,6 @@ services:
     build:
       context: .
     extra_hosts:  # send localhost traffic to the docker host, e.g. your laptop
-      - "localhost:host-gateway"
+      - "localhost:${HOST_IP:-host-gateway}"
     volumes:
       - ../.env:/.env

--- a/04-main/docker-compose.yml
+++ b/04-main/docker-compose.yml
@@ -9,6 +9,6 @@ services:
     build:
       context: .
     extra_hosts:  # send localhost traffic to the docker host, e.g. your laptop
-      - "localhost:host-gateway"
+      - "localhost:${HOST_IP:-host-gateway}"
     volumes:
       - ../.env:/.env

--- a/05-test/docker-compose.yml
+++ b/05-test/docker-compose.yml
@@ -9,8 +9,8 @@ services:
     build:
       context: .
       target: test
-    extra_hosts: # send localhost traffic to the docker host, e.g. your laptop
-      - "localhost:host-gateway"
+    extra_hosts:  # send localhost traffic to the docker host, e.g. your laptop
+      - "localhost:${HOST_IP:-host-gateway}"
     volumes:
       - ../.env:/.env
 

--- a/06-http-replay/docker-compose.yml
+++ b/06-http-replay/docker-compose.yml
@@ -16,8 +16,8 @@ services:
       context: .
       target: test
     command: -m integration
-    extra_hosts: # send localhost traffic to the docker host, e.g. your laptop
-      - "localhost:host-gateway"
+    extra_hosts:  # send localhost traffic to the docker host, e.g. your laptop
+      - "localhost:${HOST_IP:-host-gateway}"
     volumes:
       - ../.env:/.env
 

--- a/07-eval/docker-compose.yml
+++ b/07-eval/docker-compose.yml
@@ -16,8 +16,8 @@ services:
       context: .
       target: test
     command: -m integration
-    extra_hosts: # send localhost traffic to the docker host, e.g. your laptop
-      - "localhost:host-gateway"
+    extra_hosts:  # send localhost traffic to the docker host, e.g. your laptop
+      - "localhost:${HOST_IP:-host-gateway}"
     volumes:
       - ../.env:/.env
 
@@ -25,7 +25,8 @@ services:
     <<: *default-service
     container_name: eval-test
     entrypoint: [ "dotenv",  "-f", "../.env", "run", "--no-override", "--" ]
-    command: [ "sh", "-c", "opentelemetry-instrument pytest -m eval" ]
+    # Disable rerunfailures as eval test doesn't use it and it opens ports.
+    command: [ "sh", "-c", "opentelemetry-instrument pytest -p no:rerunfailures -m eval" ]
 
   main:
     <<: *default-service

--- a/README.md
+++ b/README.md
@@ -77,6 +77,16 @@ curl -L https://github.com/elastic/testing-genai-applications/archive/refs/heads
 cd testing-genai-applications-main
 ```
 
+### Podman
+
+If you are using [Podman](https://podman.io/) to run docker containers, export
+`HOST_IP`. If you don't you'll get this error running exercises:
+> unable to upgrade to tcp, received 500
+
+Here's how to export your `HOST_IP`:
+  * If macOS: `export HOST_IP=$(ipconfig getifaddr en0)`
+  * If Ubuntu: `export HOST_IP=$(hostname -I | awk '{print $1}')`
+
 ### Python
 
 All examples use the same Python virtual environment. This reduces repetition,
@@ -114,7 +124,8 @@ accessing OpenAI models. It requires an API key and may incur usage costs.
 
 To use OpenAI, do the following:
 
-1. Copy [.env.openai](.env.openai) to `.env`
+1. Copy [.env.openai](.env.openai) to a file named `.env`.
+   - `cp .env.openai .env`
 2. Set `OPENAI_API_KEY` in your `.env` file to your [Secret Key](https://platform.openai.com/account/api-keys).
 
 </details>
@@ -130,7 +141,8 @@ To start and use Ollama, do the following:
 1. Ensure `ollama` is installed
    - On macOS/Linux: `brew install ollama`
    - For Windows or otherwise, see the [download page][ollama-dl].
-2. Copy [.env.ollama](.env.ollama) to `.env`
+2. Copy [.env.ollama](.env.ollama) to a file named `.env`.
+   - `cp .env.ollama .env`
 3. In a separate terminal, run `OLLAMA_HOST=0.0.0.0 ollama serve`
    - This accepts OpenAI requests for any model on http://localhost:11434/v1
 4. In this terminal, pull the chat and eval models
@@ -148,7 +160,8 @@ locally. It is free to use, but requires sufficient computational resources.
 1. Make sure `ramalama` is installed
    - On macOS/Linux: `brew install ramalama`
    - For Windows or otherwise, see the [installation guide][ramalama-dl].
-2. Copy [.env.ramalama](.env.ramalama) to `.env`
+2. Copy [.env.ramalama](.env.ramalama) to a file named `.env`.
+   - `cp .env.ramalama .env`
 3. In a separate terminal, run `dotenv run -- sh -c 'ramalama serve ${CHAT_MODEL}'`
    - This accepts OpenAI requests for ${CHAT_MODEL} on http://localhost:8080/v1
 


### PR DESCRIPTION
This does the following:
* Fixes where we swallowed an exit code instead of propagating it. this led to false positives
* Install ramalama's dependency on llama-server, as --nocontainer is needed to conserve resources
* Add config and workarounds to podman for those running on own.